### PR TITLE
Add React Spectrum model selector to frontend for OpenAI session (Closes #27)

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -51,6 +51,7 @@ When starting a new task, make sure you are on the main branch and have the late
 - **Frontend:**  
   - Located in the `frontend/` directory.
   - Built with React and TypeScript.
+  - Uses [React Spectrum](https://react-spectrum.adobe.com/) as the component library for all UI elements.
   - Uses Vite for development and bundling (`vite.config.ts`).
   - Linting is enforced with ESLint (`eslint.config.js`) and Oxlint (`.oxlintrc.json`).
   - Testing is set up with Vitest (`vitest.config.ts`).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,8 +14,12 @@ import { useEventForm } from "./hooks/useEventForm";
 import EventFormDialog from "./components/EventFormDialog";
 import { useOpenAISession } from "./hooks/useOpenAISession";
 import { useEvents } from "./hooks/useEvents";
+import { ModelSelector, OpenAIModel } from "./components/ModelSelector";
 
 const App: React.FC = () => {
+  // Model selector state
+  const [selectedModel, setSelectedModel] = useState<OpenAIModel>("gpt-4o-realtime-preview-2024-12-17");
+
   // Event form and dialog state/logic
   const {
     eventForm,
@@ -34,17 +38,20 @@ const App: React.FC = () => {
     audioRef,
     handleStartConversation,
     handleStopConversation,
-  } = useOpenAISession((args) => {
-    // Prefill event form when function_call is received
-    openEventDialog({
-      title: args.title || "",
-      description: args.description || "",
-      startDate: args.start_time ? args.start_time.slice(0, 10) : "",
-      startTime: args.start_time ? args.start_time.slice(11, 16) : "",
-      endDate: args.end_time ? args.end_time.slice(0, 10) : "",
-      endTime: args.end_time ? args.end_time.slice(11, 16) : "",
-    });
-  });
+  } = useOpenAISession(
+    (args) => {
+      // Prefill event form when function_call is received
+      openEventDialog({
+        title: args.title || "",
+        description: args.description || "",
+        startDate: args.start_time ? args.start_time.slice(0, 10) : "",
+        startTime: args.start_time ? args.start_time.slice(11, 16) : "",
+        endDate: args.end_time ? args.end_time.slice(0, 10) : "",
+        endTime: args.end_time ? args.end_time.slice(11, 16) : "",
+      });
+    },
+    selectedModel
+  );
 
   // Events state and logic
   const { events, eventsLoading, eventsError, refreshEvents } = useEvents();
@@ -122,6 +129,12 @@ const App: React.FC = () => {
           maxWidth="size-3600"
         >
           <Heading level={1}>React Spectrum Demo</Heading>
+
+          <ModelSelector
+            value={selectedModel}
+            onChange={setSelectedModel}
+            disabled={isConversing}
+          />
 
           {conversationButton}
           <audio

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Picker, Item } from "@adobe/react-spectrum";
+
+export type OpenAIModel =
+  | "gpt-4o-realtime-preview-2024-12-17"
+  | "gpt-4o-mini-realtime-preview-2024-12-17";
+
+const MODEL_OPTIONS: { value: OpenAIModel; label: string }[] = [
+  {
+    value: "gpt-4o-realtime-preview-2024-12-17",
+    label: "GPT-4o Realtime Preview",
+  },
+  {
+    value: "gpt-4o-mini-realtime-preview-2024-12-17",
+    label: "GPT-4o Mini Realtime Preview",
+  },
+];
+
+interface ModelSelectorProps {
+  value: OpenAIModel;
+  onChange: (model: OpenAIModel) => void;
+  disabled?: boolean;
+}
+
+export const ModelSelector: React.FC<ModelSelectorProps> = ({
+  value,
+  onChange,
+  disabled = false,
+}) => (
+  <div style={{ minWidth: 260 }}>
+    <Picker
+      id="model-picker"
+      label="OpenAI Model"
+      selectedKey={value}
+      onSelectionChange={key => onChange(key as OpenAIModel)}
+      isDisabled={disabled}
+      width="100%"
+      data-testid="model-selector"
+      marginTop="size-50"
+    >
+      {MODEL_OPTIONS.map(opt => (
+        <Item key={opt.value}>{opt.label}</Item>
+      ))}
+    </Picker>
+  </div>
+);

--- a/frontend/src/hooks/useOpenAISession.ts
+++ b/frontend/src/hooks/useOpenAISession.ts
@@ -8,8 +8,9 @@ type OpenAISessionResponse = {
   [key: string]: unknown;
 };
 
-async function fetchOpenAISession(): Promise<OpenAISessionResponse> {
-  const res = await fetch("/api/openai/session");
+async function fetchOpenAISession(model: string): Promise<OpenAISessionResponse> {
+  const url = `/api/openai/session?model=${encodeURIComponent(model)}`;
+  const res = await fetch(url);
   if (!res.ok) {
     throw new Error("Failed to fetch OpenAI session: " + res.statusText);
   }
@@ -17,7 +18,8 @@ async function fetchOpenAISession(): Promise<OpenAISessionResponse> {
 }
 
 export function useOpenAISession(
-  onFunctionCall?: (args: any) => void
+  onFunctionCall?: (args: any) => void,
+  model: string = "gpt-4o-realtime-preview-2024-12-17"
 ) {
   const [isConversing, setIsConversing] = useState(false);
   const [sessionToken, setSessionToken] = useState<string | undefined>(undefined);
@@ -33,7 +35,7 @@ export function useOpenAISession(
     setPeerConnection(null);
     setLocalStream(null);
     try {
-      const data = await fetchOpenAISession();
+      const data = await fetchOpenAISession(model);
       let token: string | undefined = undefined;
       if (
         data &&
@@ -126,8 +128,7 @@ export function useOpenAISession(
       await pc.setLocalDescription(offer);
 
       const baseUrl = "https://api.openai.com/v1/realtime";
-      const model = "gpt-4o-realtime-preview-2024-12-17";
-      const sdpResponse = await fetch(`${baseUrl}?model=${model}`, {
+      const sdpResponse = await fetch(`${baseUrl}?model=${encodeURIComponent(model)}`, {
         method: "POST",
         body: offer.sdp,
         headers: {


### PR DESCRIPTION
This PR adds a model selector UI to the frontend using React Spectrum Picker, allowing users to choose between the allowed OpenAI models for ephemeral session minting. The selected model is used as the `model` URL parameter when calling `/api/openai/session`.

- Adds `ModelSelector` component using React Spectrum
- Integrates selector into the main app UI
- Wires model selection to OpenAI session logic

Closes #27.