### PR TITLE
Refactor frontend for extensible tool capabilities (Closes #21)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,7 +13,7 @@ import EventList from "./EventList";
 import { useEventForm } from "./hooks/useEventForm";
 import EventFormDialog from "./components/EventFormDialog";
 import { useOpenAISession } from "./hooks/useOpenAISession";
-import { calendarEventTool, isCalendarEventFunctionArgs } from "./tools/calendarEventTool";
+import { calendarEventTool, isCalendarEventFunctionArgs, getEventFormFromFunctionArgs } from "./tools/calendarEventTool";
 import { useEvents } from "./hooks/useEvents";
 import { ModelSelector, OpenAIModel } from "./components/ModelSelector";
 import { InstructionsEditor } from "./components/InstructionsEditor";
@@ -38,6 +38,14 @@ const App: React.FC = () => {
   } = useEventForm();
 
 
+  // Handler for OpenAI tool invocations
+  const handleOpenAITool = (toolName: string, args: unknown) => {
+    if (toolName === "create_calendar_event" && isCalendarEventFunctionArgs(args)) {
+      openEventDialog(getEventFormFromFunctionArgs(args));
+    }
+    // Future: handle other tool types here
+  };
+
   // OpenAI session and conversation logic
   const {
     isConversing,
@@ -47,19 +55,7 @@ const App: React.FC = () => {
     handleStartConversation,
     handleStopConversation,
   } = useOpenAISession(
-    (toolName, args) => {
-      if (toolName === "create_calendar_event" && isCalendarEventFunctionArgs(args)) {
-        openEventDialog({
-          title: args.title || "",
-          description: args.description || "",
-          startDate: args.start_time ? args.start_time.slice(0, 10) : "",
-          startTime: args.start_time ? args.start_time.slice(11, 16) : "",
-          endDate: args.end_time ? args.end_time.slice(0, 10) : "",
-          endTime: args.end_time ? args.end_time.slice(11, 16) : "",
-        });
-      }
-      // Future: handle other tool types here
-    },
+    handleOpenAITool,
     [calendarEventTool],
     selectedModel,
     instructions

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import EventList from "./EventList";
 import { useEventForm } from "./hooks/useEventForm";
 import EventFormDialog from "./components/EventFormDialog";
 import { useOpenAISession } from "./hooks/useOpenAISession";
+import { calendarEventTool, isCalendarEventFunctionArgs } from "./tools/calendarEventTool";
 import { useEvents } from "./hooks/useEvents";
 import { ModelSelector, OpenAIModel } from "./components/ModelSelector";
 import { InstructionsEditor } from "./components/InstructionsEditor";
@@ -36,6 +37,7 @@ const App: React.FC = () => {
     resetEventForm,
   } = useEventForm();
 
+
   // OpenAI session and conversation logic
   const {
     isConversing,
@@ -45,17 +47,20 @@ const App: React.FC = () => {
     handleStartConversation,
     handleStopConversation,
   } = useOpenAISession(
-    (args) => {
-      // Prefill event form when function_call is received
-      openEventDialog({
-        title: args.title || "",
-        description: args.description || "",
-        startDate: args.start_time ? args.start_time.slice(0, 10) : "",
-        startTime: args.start_time ? args.start_time.slice(11, 16) : "",
-        endDate: args.end_time ? args.end_time.slice(0, 10) : "",
-        endTime: args.end_time ? args.end_time.slice(11, 16) : "",
-      });
+    (toolName, args) => {
+      if (toolName === "create_calendar_event" && isCalendarEventFunctionArgs(args)) {
+        openEventDialog({
+          title: args.title || "",
+          description: args.description || "",
+          startDate: args.start_time ? args.start_time.slice(0, 10) : "",
+          startTime: args.start_time ? args.start_time.slice(11, 16) : "",
+          endDate: args.end_time ? args.end_time.slice(0, 10) : "",
+          endTime: args.end_time ? args.end_time.slice(11, 16) : "",
+        });
+      }
+      // Future: handle other tool types here
     },
+    [calendarEventTool],
     selectedModel,
     instructions
   );

--- a/frontend/src/tools/calendarEventTool.ts
+++ b/frontend/src/tools/calendarEventTool.ts
@@ -19,6 +19,20 @@ export function isCalendarEventFunctionArgs(obj: unknown): obj is CalendarEventF
   );
 }
 
+/**
+ * Convert CalendarEventFunctionArgs to the event form object expected by openEventDialog.
+ */
+export function getEventFormFromFunctionArgs(args: CalendarEventFunctionArgs) {
+  return {
+    title: args.title || "",
+    description: args.description || "",
+    startDate: args.start_time ? args.start_time.slice(0, 10) : "",
+    startTime: args.start_time ? args.start_time.slice(11, 16) : "",
+    endDate: args.end_time ? args.end_time.slice(0, 10) : "",
+    endTime: args.end_time ? args.end_time.slice(11, 16) : "",
+  };
+}
+
 // Calendar event tool schema
 export const calendarEventTool: OpenAIToolSchema = {
   type: "function",

--- a/frontend/src/tools/calendarEventTool.ts
+++ b/frontend/src/tools/calendarEventTool.ts
@@ -1,0 +1,37 @@
+import { OpenAIToolSchema } from "../hooks/useOpenAISession";
+
+// Type for calendar event function arguments
+export type CalendarEventFunctionArgs = {
+  title: string;
+  description?: string;
+  start_time: string;
+  end_time: string;
+};
+
+// Type guard for CalendarEventFunctionArgs
+export function isCalendarEventFunctionArgs(obj: unknown): obj is CalendarEventFunctionArgs {
+  if (typeof obj !== "object" || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return (
+    typeof o.title === "string" &&
+    typeof o.start_time === "string" &&
+    typeof o.end_time === "string"
+  );
+}
+
+// Calendar event tool schema
+export const calendarEventTool: OpenAIToolSchema = {
+  type: "function",
+  name: "create_calendar_event",
+  description: "Create a calendar event with structured data.",
+  parameters: {
+    type: "object",
+    properties: {
+      title: { type: "string", description: "Event title" },
+      description: { type: "string", description: "Event description" },
+      start_time: { type: "string", description: "Event start time (ISO 8601)" },
+      end_time: { type: "string", description: "Event end time (ISO 8601)" }
+    },
+    required: ["title", "start_time", "end_time"]
+  }
+};


### PR DESCRIPTION
This PR refactors the frontend architecture to support extensible assistant tool capabilities, as described in Issue #21.

- Modularizes the calendar event tool definition, types, and type guard in `src/tools/calendarEventTool.ts`
- Refactors `useOpenAISession` for generic tool registration and function call handling
- Updates `App.tsx` to import tool definitions and keep logic clean
- Prepares the codebase for future extensible assistant features (e.g., todos, notes)

Tested and confirmed working as expected.

Closes #21.